### PR TITLE
Fixed bug coming from change in python3.5 via PEP 479.

### DIFF
--- a/grepfunc/grepfunc.py
+++ b/grepfunc/grepfunc.py
@@ -231,9 +231,6 @@ def grep_iter(target, pattern, **kwargs):
         if value is not None:
             yield value
 
-    # done iteration
-    raise StopIteration
-
 
 def __process_line(line, strip_eol, strip):
     """


### PR DESCRIPTION
Since python 3.5 and [PEP 479](https://www.python.org/dev/peps/pep-0479/), StopIteration exceptions are changed to RuntimeError exceptions when raised in a generator. This change of behaviour breaks the grep_iter functions.

This fix removes the useless "raise StopIteration" at the end of grep_iter and has been tested ok with python 3.9.5 and python 2.7.16.

This pull request fixes the following open issue: #2
